### PR TITLE
Implement intro splash screen and navigation buttons

### DIFF
--- a/stillness_grove/static/css/styles.css
+++ b/stillness_grove/static/css/styles.css
@@ -19,3 +19,53 @@ body {
     margin: 0 auto;
     padding: 1rem;
 }
+
+/* Intro overlay */
+.intro {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--bg-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    animation: introFade 3s forwards;
+    z-index: 10;
+}
+
+.intro h1 {
+    font-size: 3rem;
+    margin: 0;
+}
+
+@keyframes introFade {
+    0% { opacity: 0; }
+    20% { opacity: 1; }
+    80% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* Game container */
+#game-container {
+    position: relative;
+    min-height: 100vh;
+    opacity: 0;
+    transition: opacity 1s;
+}
+
+#game-container.show {
+    opacity: 1;
+}
+
+.button-row {
+    position: absolute;
+    bottom: 20px;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}

--- a/stillness_grove/static/js/intro.js
+++ b/stillness_grove/static/js/intro.js
@@ -1,0 +1,14 @@
+const Intro = {
+    init() {
+        const intro = document.getElementById('intro');
+        const game = document.getElementById('game-container');
+        if (!intro || !game) return;
+
+        intro.addEventListener('animationend', () => {
+            intro.style.display = 'none';
+            game.classList.add('show');
+        });
+    }
+};
+
+export default Intro;

--- a/stillness_grove/static/js/main.js
+++ b/stillness_grove/static/js/main.js
@@ -1,8 +1,10 @@
 import BreathingOverlay from './breathingOverlay.js';
 import Ripple from './ripple.js';
+import Intro from './intro.js';
 
 // Initialize modules when DOM is ready
 window.addEventListener('DOMContentLoaded', () => {
+    Intro.init();
     BreathingOverlay.init();
     Ripple.init();
 });

--- a/stillness_grove/templates/base.html
+++ b/stillness_grove/templates/base.html
@@ -1,1 +1,15 @@
-<!-- Base template -->
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Stillness Grove{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    {% block content %}{% endblock %}
+    <script type="module" src="{% static 'js/main.js' %}"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/stillness_grove/templates/index.html
+++ b/stillness_grove/templates/index.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block title %}Stillness Groove{% endblock %}
+{% block content %}
+<div id="intro" class="intro">
+    <h1>Stillness Groove</h1>
+</div>
+<div id="game-container">
+    <div class="game-content">
+        <!-- Game world placeholder -->
+    </div>
+    <div class="button-row">
+        <button id="journal-btn">Journal</button>
+        <button id="meditation-btn">Meditation</button>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create base template for consistent page layout
- add index template with fading intro overlay and navigation buttons
- implement intro fade animation logic
- update main JS to run the intro effect
- style intro overlay, fade transitions, and bottom buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c370ab30833099360295af6771c2