### PR TITLE
Fix heading spelling on index page

### DIFF
--- a/stillness_grove/templates/index.html
+++ b/stillness_grove/templates/index.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% block title %}Stillness Groove{% endblock %}
+{% block title %}Stillness Grove{% endblock %}
 {% block content %}
 <div id="intro" class="intro">
-    <h1>Stillness Groove</h1>
+    <h1>Stillness Grove</h1>
 </div>
 <div id="game-container">
     <div class="game-content">


### PR DESCRIPTION
## Summary
- correct heading and title text on the index page

## Testing
- `python manage.py check`
- `python -m py_compile manage.py`


------
https://chatgpt.com/codex/tasks/task_e_6857c6d9846c8330b83d9b7be29dca78